### PR TITLE
Fix: Install python3.10-distutils to fix build

### DIFF
--- a/Dockerfile.runpod
+++ b/Dockerfile.runpod
@@ -8,7 +8,7 @@ RUN apt-get update && \
     apt-get install -y software-properties-common && \
     add-apt-repository -y ppa:deadsnakes/ppa && \
     apt-get update && \
-    apt-get install -y python3.10 python3.10-venv python3.10-dev python3-pip && \
+    apt-get install -y python3.10 python3.10-venv python3.10-dev python3-pip python3.10-distutils && \
     rm -rf /var/lib/apt/lists/*
 
 # Set python3.10 as default


### PR DESCRIPTION
This PR installs the python3.10-distutils package to resolve the ModuleNotFoundError for distutils during the Docker build.