### PR TITLE
Fix: Upgrade setuptools and wheel

### DIFF
--- a/Dockerfile.runpod
+++ b/Dockerfile.runpod
@@ -16,7 +16,7 @@ RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1
     update-alternatives --install /usr/bin/python python /usr/bin/python3.10 1
 
 # Upgrade pip
-RUN python3 -m pip install --upgrade pip
+RUN python3 -m pip install --upgrade pip setuptools wheel
 
 # Clone F5-TTS repository
 RUN git clone https://github.com/SWivid/F5-TTS.git .


### PR DESCRIPTION
This PR upgrades setuptools and wheel in the Docker build process to resolve the persistent 'distutils' ModuleNotFoundError.